### PR TITLE
Install pkg config to resolve install conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ $ yunohost app upgrade foodsoft -u https://github.com/YunoHost-Apps/foodsoft_ynh
 
 * We **do not** re-compile Nginx to use Passenger. We use the [proxy mode](https://www.phusionpassenger.com/library/deploy/standalone/reverse_proxy.html).
 * You can use the [Passenger troubleshooting documentation](https://www.phusionpassenger.com/library/admin/standalone/troubleshooting/ruby/) to help debug Passenger.
+* Please see the [YunoHost CI dashboard](https://ci-apps-dev.yunohost.org/jenkins/job/foodsoft_ynh%20(decentral1se)/) for current CI status
 
 Mirroring
 ---------

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -21,6 +21,7 @@ pkg_dependencies=" \
   libxml2-dev \
   libxslt-dev \
   libyaml-dev \
+  pkg-config \
   redis-server \
   redis-tools \
   zlib1g-dev \


### PR DESCRIPTION
## Problem
- https://ci-apps-dev.yunohost.org/jenkins/job/foodsoft_ynh%20(decentral1se)/1/
- Caused by https://github.com/YunoHost-Apps/foodsoft_ynh/issues/10.

## Solution

```
2019-07-30 22:10:11,786: DEBUG - Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
2019-07-30 22:10:11,786: DEBUG - 
2019-07-30 22:10:11,787: DEBUG -     current directory: /var/www/foodsoft/vendor/bundle/ruby/2.4.0/gems/nokogiri-1.8.1/ext/nokogiri
2019-07-30 22:10:11,787: DEBUG - /opt/rbenv/versions/2.4.6/bin/ruby -r ./siteconf20190730-13108-2il0zc.rb extconf.rb --use-system-libraries
2019-07-30 22:10:11,787: DEBUG - checking if the C compiler accepts ... yes
2019-07-30 22:10:11,787: DEBUG - Building nokogiri using system libraries.
2019-07-30 22:10:11,787: DEBUG - pkg-config could not be used to find libxml-2.0
2019-07-30 22:10:11,787: DEBUG - Please install either `pkg-config` or the pkg-config gem per
2019-07-30 22:10:11,788: DEBUG - 
2019-07-30 22:10:11,788: DEBUG -     gem install pkg-config -v "~> 1.1"
2019-07-30 22:10:11,788: DEBUG - 
```
