### PR TITLE
Ensure that the home folder is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ $ yunohost app upgrade foodsoft -u https://github.com/YunoHost-Apps/foodsoft_ynh
 
 * We **do not** re-compile Nginx to use Passenger. We use the [proxy mode](https://www.phusionpassenger.com/library/deploy/standalone/reverse_proxy.html).
 * You can use the [Passenger troubleshooting documentation](https://www.phusionpassenger.com/library/admin/standalone/troubleshooting/ruby/) to help debug Passenger.
+* Please see the [YunoHost CI dashboard](https://ci-apps-dev.yunohost.org/jenkins/job/foodsoft_ynh%20(decentral1se)/) for current CI status
 
 Mirroring
 ---------

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -21,6 +21,7 @@ pkg_dependencies=" \
   libxml2-dev \
   libxslt-dev \
   libyaml-dev \
+  pkg-config \
   redis-server \
   redis-tools \
   zlib1g-dev \

--- a/scripts/install
+++ b/scripts/install
@@ -278,6 +278,10 @@ ynh_script_progression --message="Configuring system user..." --weight=3
 
 ynh_system_user_create --username=$app --home_dir=/home/$app
 
+mkdir -p /home/$app
+
+chown -R $app:$app /home/$app
+
 #=================================================
 # MANAGE PERMISSIONS
 #=================================================


### PR DESCRIPTION
## Problem
- Passenger downloads binaries to run and needs the home directory ready.
- I had manually created this on my test environment and the script didn't handle it.

## Solution
- Create it :+1: 
